### PR TITLE
feat: add docker-based code execution MCP server

### DIFF
--- a/local-mcps/main_code_executor.py
+++ b/local-mcps/main_code_executor.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+import asyncio
+import os
+from pathlib import Path
+
+from mistralai import Mistral
+from mistralai.extra.run.context import RunContext
+from mcp import StdioServerParameters
+from mistralai.extra.mcp.stdio import MCPClientSTDIO
+from mistralai.types import BaseModel
+
+# Set the current working directory and model to use
+cwd = Path(__file__).parent
+MODEL = "mistral-medium-latest"
+
+async def main():
+    # Initialize the Mistral client with your API key
+    api_key = os.environ["MISTRAL_API_KEY"]
+    client = Mistral(api_key)
+
+    # Define parameters for the local MCP server
+    server_params = StdioServerParameters(
+        command="python",
+        args=[str((cwd / "mcp_servers/code_executor_server.py").resolve())],
+        env=None,
+    )
+
+    # Create an agent capable of executing code
+    code_agent = client.beta.agents.create(
+        model=MODEL,
+        name="code executor",
+        instructions="You can execute code snippets using the run_code tool.",
+        description="",
+    )
+
+    class CodeResult(BaseModel):
+        stdout: str
+
+    # Create a run context for the agent
+    async with RunContext(
+        agent_id=code_agent.id,
+        output_format=CodeResult,
+        continue_on_fn_error=True,
+    ) as run_ctx:
+        # Register the MCP client with the run context
+        mcp_client = MCPClientSTDIO(stdio_params=server_params)
+        await run_ctx.register_mcp_client(mcp_client=mcp_client)
+
+        # Run the agent with a query
+        run_result = await client.beta.conversations.run_async(
+            run_ctx=run_ctx,
+            inputs="Run the following Python code and return its output: print('Hello from container')",
+        )
+
+        # Print the results
+        print("All run entries:")
+        for entry in run_result.output_entries:
+            print(f"{entry}")
+            print()
+        print(f"Final model: {run_result.output_as_model}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/local-mcps/mcp_servers/code_executor_server.py
+++ b/local-mcps/mcp_servers/code_executor_server.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+"""MCP server that executes code inside Docker containers."""
+
+import subprocess
+from typing import Dict
+
+from mcp.server.fastmcp import FastMCP
+
+# Create the FastMCP server instance
+mcp = FastMCP("CodeExecutor")
+
+# Map supported languages to Docker images
+IMAGE_MAP: Dict[str, str] = {
+    "python": "python:3.11-alpine",
+}
+
+@mcp.tool()
+def run_code(language: str, program: str) -> str:
+    """Run a code snippet in a Docker container.
+
+    Args:
+        language: Programming language of the snippet.
+        program: The code to execute.
+
+    Returns:
+        Combined stdout and stderr from the execution.
+    """
+    image = IMAGE_MAP.get(language.lower())
+    if not image:
+        return f"Unsupported language: {language}"
+
+    cmd = [
+        "docker", "run", "--rm",
+        "--network", "none",
+        "--memory", "128m",
+        "--cpus", "1",
+        "-i",
+        image,
+        "python", "-c", program,
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except FileNotFoundError:
+        return "Docker is not available on this system."
+    except subprocess.SubprocessError as exc:
+        return f"Failed to run container: {exc}"
+
+    output = result.stdout or ""
+    if result.stderr:
+        output += ("\n" if output else "") + result.stderr
+    return output
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Summary
- add MCP server for executing Python snippets inside Docker containers
- provide separate main script demonstrating code execution via the new server

## Testing
- `python -m py_compile local-mcps/mcp_servers/code_executor_server.py local-mcps/main_code_executor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd6dbe43888331a0100ec3802b3c7a